### PR TITLE
Change API to lazy registered stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As is the theme, ensuring React bindings are already typed based on your `store`
 ```tsx
 import * as React from "react";
 import { render } from "react-dom";
-import { createReducer, createStore, createReactBindings } from "topstate"
+import { reducerFromHandlers, createStore, createReactBindings } from "topstate"
 
 /**
  * The central types of TopState are
@@ -60,30 +60,35 @@ type State = {
 
 const inc = { type: "inc" } as const;
 const dec = { type: "dec" } as const;
-
 type Action = typeof inc | typeof dec;
 
 /**
- * createReducer is a helper function to create reducers
+ * Create the store, passing initial State
+ * Notice we also pass the Action union type, locking it in
+ */
+let store = createStore<State, Action>({ count: 0 });
+
+
+/**
+ * reducerFromHandlers is a helper function to create reducers
  * by handling actions individually.
  * 
  * Fully typed, the `action` will be the member Action
  * specified by the key
  */
-const reducer = createReducer<State, Action>({
-    inc: state => ({count: state.count + 1}),
+const reducer = reducerFromHandlers<State, Action>({
+  inc: (state, action) => ({count: state.count + 1}),
 
-    dec: (state,action) => ({count: state.count - 1}),
+  dec: (state,action) => ({count: state.count - 1}),
 
-    // Won't type check, as this is not a membor of the Action union
-    // not_a_action: (state, action) => state
+  // Won't type check, as this is not a membor of the Action union
+  // not_a_action: (state, action) => state
 })
 
 /**
- * Create the store, passing initial State and the reducer
- * Notice we also pass the Action union type, locking it in
+ * register the reducer in the store
  */
-const store = createStore<State, Action>({ count: 0 }, reducer);
+const removeReducer = store.addReducer(reducer);
 
 /**
  * We "create" the React bindings, again passing the State & Action types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topstate",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "author": {
     "email": "max.willmo@gmail.com",
     "name": "Max Willmott",

--- a/src/__tests__/react.spec.tsx
+++ b/src/__tests__/react.spec.tsx
@@ -19,16 +19,16 @@ const {
 const initialState: TestState = { foo: 0 };
 const store = createStore<TestState, TestAction>(
 	initialState,
-	(s, a) => {
-		switch (a.type) {
-			case "inc":
-				return { foo: s.foo + 1 };
-			default:
-				return s;
-		}
-	},
 	createNoopLogger()
 );
+store.addReducer((s, a) => {
+	switch (a.type) {
+		case "inc":
+			return { foo: s.foo + 1 };
+		default:
+			return s;
+	}
+});
 
 const wrapper = ({ children }: { children: React.ReactChildren }) => (
 	<StoreContext.Provider value={store}>{children}</StoreContext.Provider>
@@ -70,6 +70,6 @@ describe("react", () => {
 			expect(result.current).toEqual(nextFoo);
 		});
 
-		//todo add case ensuring component does NOT rerender upon a selector resulting in same value
+		// todo add case ensuring component does NOT rerender upon a selector resulting in same value
 	});
 });

--- a/src/__tests__/selectors.spec.ts
+++ b/src/__tests__/selectors.spec.ts
@@ -46,7 +46,7 @@ describe("selectors", () => {
 		it("should memoize the selector", () => {
 			const state: TestState = { foo: 100 };
 
-			//ensure the args to selector_ab are ref eq
+			// ensure the args to selector_ab are ref eq
 			const selector_a = createSelector<TestState, {}>((s) => s);
 			const selector_b = createSelector<TestState, {}>((s) => s);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,4 +25,6 @@ export type Store<S, A extends Action> = {
 	getState: GetState<S>;
 	dispatch: Dispatcher<S, A>;
 	subscribe: (cb: Subscriber<S>) => () => void;
+	addReducer: (reducer: Reducer<S, A>) => () => void;
+	addSubReducer: <K extends keyof S>(key: K, reducer: Reducer<S[K], A>) => () => void;
 };


### PR DESCRIPTION
In another attempt to nicely type sub reducers we replace the `createReducer` & `createSubReducer` functions with methods on the store instead. This enables better typing on the `createSubReducer` (the original goal) but also dynamic registration and de-registration of reducers, enabling code splitting apps.