### PR TITLE
Action hooks deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topstate",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "email": "max.willmo@gmail.com",
     "name": "Max Willmott",

--- a/src/createReactBindings.ts
+++ b/src/createReactBindings.ts
@@ -42,21 +42,21 @@ export function createReactBindings<S, A extends Action>(): StoreReact<S, A> {
 		return result;
 	};
 
-	const useActionCreator: UseActionCreator<A> = <B = void>(actionCreator: (b: B) => A) => {
+	const useActionCreator: UseActionCreator<A> = <B = void>(actionCreator: (b: B) => A, additionalDeps: any[] = []) => {
 		const dispatch = useDispatch();
 		return useCallback(
 			(b: B) => {
 				dispatch(actionCreator(b));
 			},
-			[dispatch]
+			[dispatch, ...additionalDeps]
 		);
 	};
 
-	const useAction: UseAction<S, A> = (action) => {
+	const useAction: UseAction<S, A> = (action, additionalDeps = []) => {
 		const dispatch = useDispatch();
 		return useCallback(() => {
 			dispatch(action);
-		}, [dispatch]);
+		}, [dispatch, ...additionalDeps]);
 	};
 
 	return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,7 +195,8 @@ export type UseAction<S, A extends Action> = (action: A | ActionThunk<S, A>) => 
  * ```
  */
 export type UseActionCreator<A extends Action> = <B = void>(
-	actionCreator: (b: B) => A
+	actionCreator: (b: B) => A,
+	additionalDeps?: any[]
 ) => (b: B) => void;
 
 /** @category Primary API */


### PR DESCRIPTION
Update `useAction` and `useActionCreator` to take React hooks deps as an additional argument. You do not need to respecify the `dispatch` function in here. This resolves the issue of using data inside which is dynamic to the Component instance.